### PR TITLE
v2.0

### DIFF
--- a/netdev-automount
+++ b/netdev-automount
@@ -77,9 +77,6 @@ def mounted(mountpoint: str) -> bool:
 # mount <netmounts> if reachable
 def mount(netmounts: list[tuple[str,str]]):
     for host,mount in netmounts:
-        if not reachable(host):
-            print(f'Host {host} not reachable. Not mounting {mount}')
-            return
         if mounted(mount):
             print(f'{mount} already mounted')
             return
@@ -92,20 +89,17 @@ def mount(netmounts: list[tuple[str,str]]):
 # unmount <netmounts> if unreachable
 def umount(netmounts: list[tuple[str,str]]):
     for host,mount in netmounts:
-        if reachable(host):
-            print(f'Host {host} still reachable - Not unmounting {mount}')
-            return
         if not mounted(mount):
             print(f'{mount} already unmounted')
             return
         # try to unmount clean first
-        for args in ['', '-f', '-lf']:
+        for args in [' ', '-f', '-lf']:
             p = subprocess.run(['timeout', '3', 'umount', args, mount], capture_output=True)
             if p.returncode == 0:
-                print(f'Successfully unmounted {mount} from {host}')
-                break
+                print(f'Successfully unmounted {mount} from {host} with args {args}')
+                return
             else:
-                print(f'Failed unmounting {mount} from {host}')
+                print(f'Failed unmounting {mount} from {host} with args {args}')
 
 # returns True if ran from a valid NetworkManager/dispatcher.d
 def nm_dispatcher() -> bool:
@@ -142,17 +136,20 @@ def nm_dispatcher_events():
     
     # mount based on dispatched event
     # wait until the default gateway for interface is available
+    # then retry 5 times with 3s delay
     if sys.argv[2] in ['up', 'vpn-up']:
         while not gateway(sys.argv[1]) and not reachable(str(gateway(sys.argv[1]))): time.sleep(1)
-        mount([ x for x in parse_fstab() if x[0] in hosts ])
+        for i in range(5):
+            mount([ x for x in parse_fstab() if x[0] in hosts and reachable(x[0]) ])
+            time.sleep(3)
     elif sys.argv[2] in ['pre-down', 'down', 'vpn-pre-down', 'vpn-down']:
         umount([ x for x in parse_fstab() if x[0] in hosts ])
     exit()
 
 # Events when running directly
 def direct():
-    mount([ x for x in parse_fstab() ])
-    umount([ x for x in parse_fstab() ])
+    mount([ x for x in parse_fstab() if reachable(x[0]) ])
+    umount([ x for x in parse_fstab() if not reachable(x[0]) ])
     exit()
 
 # create default conf if it doesn't exist

--- a/netdev-automount
+++ b/netdev-automount
@@ -67,9 +67,12 @@ def gateway(iface: str) -> str|None:
                 return route[1]
 
 # returns True if mountpoint already has a FS mounted
+# if it doesn't finish within 3 seconds assume it's
+# a mounted but disconnected zombie netmount
 def mounted(mountpoint: str) -> bool:
-    p = subprocess.run(['mountpoint', mountpoint], capture_output=True)
-    return p.returncode == 0
+    p = subprocess.run(['timeout', '3', 'mountpoint', mountpoint], capture_output=True)
+    # 124 -> timeout
+    return p.returncode == 0 or p.returncode == 124
 
 # mount <netmounts> if reachable
 def mount(netmounts: list[tuple[str,str]]):
@@ -95,11 +98,14 @@ def umount(netmounts: list[tuple[str,str]]):
         if not mounted(mount):
             print(f'{mount} already unmounted')
             return
-        p = subprocess.run(['umount', '-lf', mount], capture_output=True)
-        if p.returncode == 0:
-            print(f'Successfully unmounted {mount} from {host}')
-        else:
-            print(f'Failed unmounting {mount} from {host}')
+        # try to unmount clean first
+        for args in ['', '-f', '-lf']:
+            p = subprocess.run(['timeout', '3', 'umount', args, mount], capture_output=True)
+            if p.returncode == 0:
+                print(f'Successfully unmounted {mount} from {host}')
+                break
+            else:
+                print(f'Failed unmounting {mount} from {host}')
 
 # returns True if ran from a valid NetworkManager/dispatcher.d
 def nm_dispatcher() -> bool:

--- a/netdev-automount
+++ b/netdev-automount
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import sys,os,re,subprocess,tomllib
+import sys,os,re,subprocess,tomllib,time
 
 '''
 Automatically (un)mount network filesystems
@@ -53,6 +53,18 @@ def reachable(host: str) -> bool:
         return True
     else:
         return False
+
+# get default gateway(ipv4)/next hop(ipv6) for iface
+# either returns ip if found or None
+def gateway(iface: str) -> str|None:
+    for ipv in ['6', '4']:
+        route = subprocess.run(['route', '-n', f'-{ipv}'], capture_output=True, text=True)
+        if route.returncode != 0:
+            return None
+        for line in route.stdout.splitlines():
+            route = re.split(r'\s+', line)
+            if iface in route and 'UG' in route:
+                return route[1]
 
 # returns True if mountpoint already has a FS mounted
 def mounted(mountpoint: str) -> bool:
@@ -123,7 +135,9 @@ def nm_dispatcher_events():
         exit()
     
     # mount based on dispatched event
+    # wait until the default gateway for interface is available
     if sys.argv[2] in ['up', 'vpn-up']:
+        while not gateway(sys.argv[1]) and not reachable(str(gateway(sys.argv[1]))): time.sleep(1)
         mount([ x for x in parse_fstab() if x[0] in hosts ])
     elif sys.argv[2] in ['pre-down', 'down', 'vpn-pre-down', 'vpn-down']:
         umount([ x for x in parse_fstab() if x[0] in hosts ])

--- a/netdev-automount
+++ b/netdev-automount
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 
-import sys,os,re,subprocess,tomllib,time
+import sys
+import os
+import re
+import subprocess
+import tomllib
+import time
+import concurrent.futures
 
 '''
 Automatically (un)mount network filesystems
@@ -70,36 +76,56 @@ def gateway(iface: str) -> str|None:
 # if it doesn't finish within 3 seconds assume it's
 # a mounted but disconnected zombie netmount
 def mounted(mountpoint: str) -> bool:
-    p = subprocess.run(['timeout', '3', 'mountpoint', mountpoint], capture_output=True)
-    # 124 -> timeout
-    return p.returncode == 0 or p.returncode == 124
+    try:
+        p = subprocess.run(['mountpoint', mountpoint], capture_output=True, timeout=5)
+        return p.returncode == 0
+    except subprocess.TimeoutExpired:
+        return True
 
 # mount <netmounts> if reachable
-def mount(netmounts: list[tuple[str,str]]):
-    for host,mount in netmounts:
-        if mounted(mount):
-            print(f'{mount} already mounted')
-            return
-        p = subprocess.run(['mount', mount], capture_output=True)
+def mount(netmount: tuple[str,str]):
+    host,mount = netmount
+    if mounted(mount):
+        print(f'{mount} already mounted')
+        return
+    try:
+        p = subprocess.run(['mount', mount], capture_output=True, )
         if p.returncode == 0:
             print(f'Successfully mounted {mount} from {host}')
         else:
-            print(f'Failed mounting {mount} from {host}')
+            print(f'Failed mounting {mount} from {host} - mount failed')
+    except subprocess.TimeoutExpired:
+        print(f'Failed mounting {mount} from {host} - timeout reached')
 
 # unmount <netmounts> if unreachable
-def umount(netmounts: list[tuple[str,str]]):
-    for host,mount in netmounts:
-        if not mounted(mount):
-            print(f'{mount} already unmounted')
-            return
-        # try to unmount clean first
-        for args in [' ', '-f', '-lf']:
-            p = subprocess.run(['timeout', '3', 'umount', args, mount], capture_output=True)
+def unmount(netmount: tuple[str,str]):
+    host,mount = netmount
+    if not mounted(mount):
+        print(f'{mount} already unmounted')
+        return
+    # try to unmount clean first
+    for args in [' ', '-f', '-lf']:
+        try:
+            p = subprocess.run(['umount', args, mount], capture_output=True, timeout=5)
             if p.returncode == 0:
                 print(f'Successfully unmounted {mount} from {host} with args {args}')
                 return
             else:
-                print(f'Failed unmounting {mount} from {host} with args {args}')
+                print(f'Failed unmounting {mount} from {host} with args {args} - umount failed')
+        except subprocess.TimeoutExpired:
+            print(f'Failed unmounting {mount} from {host} with args {args} - timeout reached')
+
+# start parallel mountjobs
+def mounter(action: str, netmounts: list[tuple[str,str]]):
+    if action not in ['mount', 'unmount']:
+        raise ValueError("action should be one of [mount, unmount]")
+    mountjobs = concurrent.futures.ThreadPoolExecutor()
+    for netmount in netmounts:
+        if action == 'mount':
+            mountjobs.submit(mount, netmount)
+        elif action == 'unmount':
+            mountjobs.submit(unmount, netmount)
+    mountjobs.shutdown(wait=True)
 
 # returns True if ran from a valid NetworkManager/dispatcher.d
 def nm_dispatcher() -> bool:
@@ -140,16 +166,16 @@ def nm_dispatcher_events():
     if sys.argv[2] in ['up', 'vpn-up']:
         while not gateway(sys.argv[1]) and not reachable(str(gateway(sys.argv[1]))): time.sleep(1)
         for i in range(5):
-            mount([ x for x in parse_fstab() if x[0] in hosts and reachable(x[0]) ])
+            mounter('mount', [x for x in parse_fstab() if x[0] in hosts])
             time.sleep(3)
     elif sys.argv[2] in ['pre-down', 'down', 'vpn-pre-down', 'vpn-down']:
-        umount([ x for x in parse_fstab() if x[0] in hosts ])
+        mounter('unmount', [x for x in parse_fstab() if x[0] in hosts])
     exit()
 
 # Events when running directly
 def direct():
-    mount([ x for x in parse_fstab() if reachable(x[0]) ])
-    umount([ x for x in parse_fstab() if not reachable(x[0]) ])
+    mounter('mount', [x for x in parse_fstab()])
+    mounter('unmount', [x for x in parse_fstab()])
     exit()
 
 # create default conf if it doesn't exist

--- a/netdev-automount
+++ b/netdev-automount
@@ -54,8 +54,8 @@ def parse_fstab() -> list[tuple[str,str]]:
 # @param tries - try check n times (default 1)
 # @return - True if reachable, else False
 def reachable(host: str, tries: int = 1) -> bool:
-    for t in range(1, tries):
-        if t > 1:
+    for t in range(tries):
+        if t > 0:
             sleep(3)
         try:
             # resolve host outide of ping because ping's resolver is slow
@@ -86,13 +86,14 @@ def mounted(mountpoint: str) -> bool:
 
 # mount <netmounts>
 # @param netmount - tuple of (host, mount)
-# @param check_reachable - None disables check, int retries check n times (default 5 tries)
-def mount(netmount: tuple[str,str], check_reachable: None|int = 5) -> None:
+# @param check_reachable - None disables check, int retries check n times (default disable)
+def mount(netmount: tuple[str,str], check_reachable: None|int) -> None:
     host,mount = netmount
     if mounted(mount):
         print(f'{mount} already mounted')
         return
     if check_reachable and not reachable(host, check_reachable):
+        print(f'{host} unreachable - not mounting')
         return
     try:
         p = subprocess.run(['mount', mount], capture_output=True, timeout=5)
@@ -105,13 +106,14 @@ def mount(netmount: tuple[str,str], check_reachable: None|int = 5) -> None:
 
 # unmount <netmounts>
 # @param netmount - tuple of (host, mount)
-# @param check_reachable - None disables check, int retries check n times (default 1 try)
-def unmount(netmount: tuple[str,str], check_reachable: None|int = 1) -> None:
+# @param check_reachable - None disables check, int retries check n times (default disable)
+def unmount(netmount: tuple[str,str], check_reachable: None|int) -> None:
     host,mount = netmount
     if not mounted(mount):
         print(f'{mount} already unmounted')
         return
     if check_reachable and reachable(host, check_reachable):
+        print(f'{host} reachable - not unmounting')
         return
     # try to unmount clean first
     for args in [(), ('-f'), ('-l', '-f')]:
@@ -128,15 +130,16 @@ def unmount(netmount: tuple[str,str], check_reachable: None|int = 1) -> None:
 # start parallel mountjobs
 # @param action - one of mount or unmount
 # @param netmounts - list of (host, mountpoint) tuples
-def mounter(action: str, netmounts: list[tuple[str,str]]) -> None:
+# @param check_reachable - None disables check, int retries check n times (default disable)
+def mounter(action: str, netmounts: list[tuple[str,str]], check_reachable: None|int = None) -> None:
     if action not in ['mount', 'unmount']:
         raise ValueError("action should be one of [mount, unmount]")
     mountjobs = concurrent.futures.ThreadPoolExecutor()
     for netmount in netmounts:
         if action == 'mount':
-            mountjobs.submit(mount, netmount)
+            mountjobs.submit(mount, netmount, check_reachable)
         elif action == 'unmount':
-            mountjobs.submit(unmount, netmount)
+            mountjobs.submit(unmount, netmount, check_reachable)
     mountjobs.shutdown(wait=True)
 
 # check if NetworkManager-dispatcher
@@ -174,17 +177,20 @@ def nm_dispatcher_events():
     else:
         exit()
     
-    # mount based on dispatched event
+    # act based on dispatched event
     if sys.argv[2] in ['up', 'vpn-up']:
-        mounter('mount', [x for x in parse_fstab() if x[0] in hosts])
+        # mount valid hosts and allow 5 retries for checking reachability
+        mounter('mount', [x for x in parse_fstab() if x[0] in hosts], check_reachable=5)
     elif sys.argv[2] in ['pre-down', 'down', 'vpn-pre-down', 'vpn-down']:
-        mounter('unmount', [x for x in parse_fstab() if x[0] in hosts])
+        # unmount valid hosts without checking reachability
+        mounter('unmount', [x for x in parse_fstab() if x[0] in hosts], check_reachable=None)
     exit()
 
 # Events when running directly
 def direct():
-    mounter('mount', [x for x in parse_fstab()])
-    mounter('unmount', [x for x in parse_fstab()])
+    # (un)mount hosts, only check reachability once
+    mounter('mount', [x for x in parse_fstab()], check_reachable=1)
+    mounter('unmount', [x for x in parse_fstab()], check_reachable=1)
     exit()
 
 # create default conf if it doesn't exist

--- a/netdev-automount
+++ b/netdev-automount
@@ -114,9 +114,9 @@ def unmount(netmount: tuple[str,str], check_reachable: None|int = 1) -> None:
     if check_reachable and reachable(host, check_reachable):
         return
     # try to unmount clean first
-    for args in [' ', '-f', '-lf']:
+    for args in [(), ('-f'), ('-l', '-f')]:
         try:
-            p = subprocess.run(['umount', args, mount], capture_output=True, timeout=5)
+            p = subprocess.run(['umount', *args, mount], capture_output=True, timeout=5)
             if p.returncode == 0:
                 print(f'Successfully unmounted {mount} from {host} with args {args}')
                 return

--- a/netdev-automount
+++ b/netdev-automount
@@ -5,7 +5,7 @@ import os
 import re
 import subprocess
 import tomllib
-import time
+from time import sleep
 import concurrent.futures
 
 '''
@@ -30,7 +30,8 @@ Hosts are as configured in fstab.
 # hosts = [ 'host_1', 'host_2', 'host_3' ]
 '''
 
-# returns a list of tuples containing (host, mountpoint)
+# parse /etc/fstab for netmounts
+# @return - list of tuples containing (host, mountpoint)
 def parse_fstab() -> list[tuple[str,str]]:
     shares = list[tuple[str,str]]()
     with open('/etc/fstab') as fstab:
@@ -47,22 +48,35 @@ def parse_fstab() -> list[tuple[str,str]]:
             shares.append((host, mountpoint))
     return shares
 
-# returns True if host is reachable
-def reachable(host: str) -> bool:
-    # resolve host outide of ping because ping's resolver is slow
-    getent = subprocess.run(['getent', 'hosts', host], capture_output=True, text=True)
-    if getent.returncode != 0:
-        return False
-    ip = getent.stdout.split(' ')[0]
-    ping = subprocess.run(['ping', '-c1', ip], capture_output=True)
-    if ping.returncode == 0:
-        return True
+# check if host is reachable
+# retry 'tries' times waiting 3s between tries
+# @param host - host to check
+# @param tries - try check n times (default 1)
+# @return - True if reachable, else False
+def reachable(host: str, tries: int = 1) -> bool:
+    for t in range(1, tries):
+        if t > 1:
+            sleep(3)
+        try:
+            # resolve host outide of ping because ping's resolver is slow
+            getent = subprocess.run(['getent', 'hosts', host], capture_output=True, text=True, timeout=5)
+            if getent.returncode != 0:
+                continue
+            ip = getent.stdout.split(' ')[0]
+            ping = subprocess.run(['ping', '-c1', ip], capture_output=True, timeout=5)
+            if ping.returncode == 0:
+                return True
+            else:
+                continue
+        except subprocess.TimeoutExpired:
+            continue
     else:
         return False
 
-# returns True if mountpoint already has a FS mounted
-# if it doesn't finish within 3 seconds assume it's
-# a mounted but disconnected zombie netmount
+# check if mountpoint is mounted
+# assume timeout means unreachable zombie netmount
+# @param mountpoint - path to a local mountpoint
+# @return - True if mountpoint mounted or timeout, else False
 def mounted(mountpoint: str) -> bool:
     try:
         p = subprocess.run(['mountpoint', mountpoint], capture_output=True, timeout=5)
@@ -70,14 +84,18 @@ def mounted(mountpoint: str) -> bool:
     except subprocess.TimeoutExpired:
         return True
 
-# mount <netmounts> if reachable
-def mount(netmount: tuple[str,str]):
+# mount <netmounts>
+# @param netmount - tuple of (host, mount)
+# @param check_reachable - None disables check, int retries check n times (default 5 tries)
+def mount(netmount: tuple[str,str], check_reachable: None|int = 5) -> None:
     host,mount = netmount
     if mounted(mount):
         print(f'{mount} already mounted')
         return
+    if check_reachable and not reachable(host, check_reachable):
+        return
     try:
-        p = subprocess.run(['mount', mount], capture_output=True, )
+        p = subprocess.run(['mount', mount], capture_output=True, timeout=5)
         if p.returncode == 0:
             print(f'Successfully mounted {mount} from {host}')
         else:
@@ -85,11 +103,15 @@ def mount(netmount: tuple[str,str]):
     except subprocess.TimeoutExpired:
         print(f'Failed mounting {mount} from {host} - timeout reached')
 
-# unmount <netmounts> if unreachable
-def unmount(netmount: tuple[str,str]):
+# unmount <netmounts>
+# @param netmount - tuple of (host, mount)
+# @param check_reachable - None disables check, int retries check n times (default 1 try)
+def unmount(netmount: tuple[str,str], check_reachable: None|int = 1) -> None:
     host,mount = netmount
     if not mounted(mount):
         print(f'{mount} already unmounted')
+        return
+    if check_reachable and reachable(host, check_reachable):
         return
     # try to unmount clean first
     for args in [' ', '-f', '-lf']:
@@ -104,7 +126,9 @@ def unmount(netmount: tuple[str,str]):
             print(f'Failed unmounting {mount} from {host} with args {args} - timeout reached')
 
 # start parallel mountjobs
-def mounter(action: str, netmounts: list[tuple[str,str]]):
+# @param action - one of mount or unmount
+# @param netmounts - list of (host, mountpoint) tuples
+def mounter(action: str, netmounts: list[tuple[str,str]]) -> None:
     if action not in ['mount', 'unmount']:
         raise ValueError("action should be one of [mount, unmount]")
     mountjobs = concurrent.futures.ThreadPoolExecutor()
@@ -115,14 +139,16 @@ def mounter(action: str, netmounts: list[tuple[str,str]]):
             mountjobs.submit(unmount, netmount)
     mountjobs.shutdown(wait=True)
 
-# returns True if ran from a valid NetworkManager/dispatcher.d
+# check if NetworkManager-dispatcher
+# @return - True if ran from a valid NetworkManager/dispatcher.d, else False
 def nm_dispatcher() -> bool:
     if re.match(r'/(?:etc|usr/lib)/NetworkManager/dispatcher.d/.*', os.path.abspath(__file__)):
         return True
     else:
         return False
 
-# returns list of hosts associated with NetworkManager <connection>
+# parse configured hosts from /etc/nm-netdev-automount.tomle
+# @return - list of hosts associated with NetworkManager <connection>
 def nm_dispatcher_hosts(connection: str) -> list[str] | None:
     config_path = '/etc/nm-netdev-automount.toml'
     with open(config_path, 'rb') as f:

--- a/netdev-automount
+++ b/netdev-automount
@@ -60,18 +60,6 @@ def reachable(host: str) -> bool:
     else:
         return False
 
-# get default gateway(ipv4)/next hop(ipv6) for iface
-# either returns ip if found or None
-def gateway(iface: str) -> str|None:
-    for ipv in ['6', '4']:
-        route = subprocess.run(['route', '-n', f'-{ipv}'], capture_output=True, text=True)
-        if route.returncode != 0:
-            return None
-        for line in route.stdout.splitlines():
-            route = re.split(r'\s+', line)
-            if iface in route and 'UG' in route:
-                return route[1]
-
 # returns True if mountpoint already has a FS mounted
 # if it doesn't finish within 3 seconds assume it's
 # a mounted but disconnected zombie netmount
@@ -161,13 +149,8 @@ def nm_dispatcher_events():
         exit()
     
     # mount based on dispatched event
-    # wait until the default gateway for interface is available
-    # then retry 5 times with 3s delay
     if sys.argv[2] in ['up', 'vpn-up']:
-        while not gateway(sys.argv[1]) and not reachable(str(gateway(sys.argv[1]))): time.sleep(1)
-        for i in range(5):
-            mounter('mount', [x for x in parse_fstab() if x[0] in hosts])
-            time.sleep(3)
+        mounter('mount', [x for x in parse_fstab() if x[0] in hosts])
     elif sys.argv[2] in ['pre-down', 'down', 'vpn-pre-down', 'vpn-down']:
         mounter('unmount', [x for x in parse_fstab() if x[0] in hosts])
     exit()

--- a/netdev-automount
+++ b/netdev-automount
@@ -37,7 +37,7 @@ def parse_fstab() -> list[tuple[str,str]]:
             if not re.match(r'.*?:.*?(?:\s+.*?){5}', line):
                 continue
             host = re.sub(r'\s*(.*?):.*?\s+.*', r'\1', line.rstrip())
-            mountpoint = re.sub(r'\s*.*?:(.*?)\s+.*', r'\1', line.rstrip())
+            mountpoint = re.sub(r'\s*.*?\s+(.*?)\s+.*', r'\1', line.rstrip())
             shares.append((host, mountpoint))
     return shares
 
@@ -57,34 +57,37 @@ def reachable(host: str) -> bool:
 # returns True if mountpoint already has a FS mounted
 def mounted(mountpoint: str) -> bool:
     p = subprocess.run(['mountpoint', mountpoint], capture_output=True)
-    if p.returncode == 0:
-        return True
-    else:
-        return False
+    return p.returncode == 0
 
-# mount <mountpoints> print error on fail
-def mount(mountpoints: list[str]):
-    for mountpoint in mountpoints:
-        if not mounted(mountpoint):
-            p = subprocess.run(['mount', mountpoint], capture_output=True)
-            if p.returncode == 0:
-                print(f'Successfully mounted {mountpoint}')
-            else:
-                print(f'Failed mounting {mountpoint}')
+# mount <netmounts> if reachable
+def mount(netmounts: list[tuple[str,str]]):
+    for host,mount in netmounts:
+        if not reachable(host):
+            print(f'Host {host} not reachable. Not mounting {mount}')
+            return
+        if mounted(mount):
+            print(f'{mount} already mounted')
+            return
+        p = subprocess.run(['mount', mount], capture_output=True)
+        if p.returncode == 0:
+            print(f'Successfully mounted {mount} from {host}')
         else:
-            print(f'{mountpoint} already mounted')
+            print(f'Failed mounting {mount} from {host}')
 
-# unmount <mountpoints> print error on fail
-def umount(mountpoints: list[str]):
-    for mountpoint in mountpoints:
-        if mounted(mountpoint):
-            p = subprocess.run(['umount', '-lf', mountpoint], capture_output=True)
-            if p.returncode == 0:
-                print(f'Successfully unmounted {mountpoint}')
-            else:
-                print(f'Failed unmounting {mountpoint}')
+# unmount <netmounts> if unreachable
+def umount(netmounts: list[tuple[str,str]]):
+    for host,mount in netmounts:
+        if reachable(host):
+            print(f'Host {host} still reachable - Not unmounting {mount}')
+            return
+        if not mounted(mount):
+            print(f'{mount} already unmounted')
+            return
+        p = subprocess.run(['umount', '-lf', mount], capture_output=True)
+        if p.returncode == 0:
+            print(f'Successfully unmounted {mount} from {host}')
         else:
-            print(f'{mountpoint} not mounted')
+            print(f'Failed unmounting {mount} from {host}')
 
 # returns True if ran from a valid NetworkManager/dispatcher.d
 def nm_dispatcher() -> bool:
@@ -119,19 +122,17 @@ def nm_dispatcher_events():
     else:
         exit()
     
-    # mount based on dispatched event and reachable status
-    # unmount based only on dispatched event
+    # mount based on dispatched event
     if sys.argv[2] in ['up', 'vpn-up']:
-        mount([ x[1] for x in parse_fstab() if x[0] in hosts and reachable(x[0]) ])
+        mount([ x for x in parse_fstab() if x[0] in hosts ])
     elif sys.argv[2] in ['pre-down', 'down', 'vpn-pre-down', 'vpn-down']:
-        umount([ x[1] for x in parse_fstab() if x[0] in hosts])
+        umount([ x for x in parse_fstab() if x[0] in hosts ])
     exit()
 
 # Events when running directly
 def direct():
-    # (un)mount based on reachable status
-    mount([ x[1] for x in parse_fstab() if reachable(x[0]) ])
-    umount([ x[1] for x in parse_fstab() if not reachable(x[0]) ])
+    mount([ x for x in parse_fstab() ])
+    umount([ x for x in parse_fstab() ])
     exit()
 
 # create default conf if it doesn't exist


### PR DESCRIPTION
Key changes:
- parallel (un)mount jobs via `concurrent.futures`
- more robust reachability checking:
  - (nm): retry up to 5 times with 3s delay for mount
  - (nm): unconditionally unmount (the interface is down so trying to reach a host causes more harm than good)
  - (direct): run the checks once for mount and unmount
- command timeouts to avoid blocking
- unmount now tries to unmount gracefully first, after a timeout retries with `-f` and after another timeout with `-l -f`
- better function docs